### PR TITLE
Add digitalocean provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ DOMAIN_NAME="example.org" \
     ./lego.sh
 ```
 
+If you're using DigitalOcean, you need to [create an API](https://cloud.digitalocean.com/account/api/tokens) token first.
+
+Then run the script:
+
+```bash
+DOMAIN_NAME="example.org" \
+    EMAIL="you@email" \
+    DNS_PROVIDER="digitalocean" \
+    DO_AUTH_TOKEN="yourapitoken" \
+    ./lego.sh
+```
+
 By default, it uses [Let's Encrypt](https://letsencrypt.org/) to generate the certificate.
 
 Alternatively, you can use a different provider. For instance, [ZeroSSL](https://zerossl.com/).


### PR DESCRIPTION
I found this script through a guide involving setting adguard up on digitalocean, but noticed that it only had support for cloudflare and godaddy DNS. i added the support for digitalocean and tested it to work