### PR TITLE
Add support for multiple domain names

### DIFF
--- a/lego.sh
+++ b/lego.sh
@@ -6,7 +6,10 @@ set -e -f -u
 
 # Env configuration
 #
-# DOMAIN_NAME       Main domain name we're obtaining a wildcard certificate for.
+# DOMAIN_NAME       Main domain name(s) we're obtaining a wildcard certificate for. Can be either a single domain name 
+#                   or a comma separated list. For a comma separated list, do not include spaces between values and
+#                   only use the base (no wildcard) domain, ie: "dns.example.com,dns.differentexample.com"
+#
 # DNS_PROVIDER      DNS provider lego uses to prove that you're in control of
 # 					the domain. The current version supports "godaddy" and "cloudflare".
 # EMAIL				Your email address.
@@ -312,8 +315,8 @@ run_lego_duckdns() {
 }
 
 run_lego() {
-    domainName="${DOMAIN_NAME}"
-    wildcardDomainName="*.${DOMAIN_NAME}"
+    domainName="${DOMAIN_STRING}"
+    wildcardDomainName="${WILDCARD_STRING}"
     email="${EMAIL}"
 
     case ${DNS_PROVIDER} in
@@ -345,13 +348,22 @@ get_abs_filename() {
 }
 
 copy_certificate() {
-    certFileName="${DOMAIN_NAME}"
+    certFileName="${DOMAIN_ARRAY[0]}"
     cp -f "./.lego/certificates/_.${certFileName}.key" "./${certFileName}.key"
     cp -f "./.lego/certificates/_.${certFileName}.crt" "./${certFileName}.crt"
 
     log "Your certificate and key are available at:"
     log "$(get_abs_filename ${certFileName}.crt)"
     log "$(get_abs_filename ${certFileName}.key)"
+}
+
+parse_domain_names() {
+    IFS="," read -ra DOMAIN_ARRAY <<< "$DOMAIN_NAME"
+    WILDCARD_ARRAY=( "${DOMAIN_ARRAY[@]/#/*.}" )
+    printf -v DOMAIN_STRING '%s,' "${DOMAIN_ARRAY[@]}"
+    printf -v WILDCARD_STRING '%s,' "${WILDCARD_ARRAY[@]}"
+    DOMAIN_STRING="${DOMAIN_STRING%,}"
+    WILDCARD_STRING="${WILDCARD_STRING%,}"
 }
 
 # Entrypoint
@@ -369,6 +381,8 @@ check_env
 set_os
 
 set_cpu
+
+parse_domain_names
 
 download_lego
 


### PR DESCRIPTION
Solves issue ameshkov/legoagh#11

TESTING: Tested with both a single and 2 domains when using cloudflare DNS. Should work for all providers that `lego` supports.

Add `parse_domain_names()` function to convert a string of comma separated domains (or a single domain) into 2 variables, one containing original domains and one containing wildcard domains.

Change `certFileName` to use the first value of the `DOMAIN_ARRAY` to prevent it from breaking saving the cert and key files

Change `run_lego()` function to use the comma separated strings created in `parse_domain_names()` function